### PR TITLE
feat(attr): object mapper cast to object

### DIFF
--- a/src/Attributes/ArrayEachMapper.php
+++ b/src/Attributes/ArrayEachMapper.php
@@ -9,7 +9,7 @@ use Override;
 use Sylarele\ObjectMetadataMapper\Helpers\Arr;
 
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
-final readonly class ObjectEachMapper extends Mapper
+final readonly class ArrayEachMapper extends Mapper
 {
     /** @var array<Mapper> */
     public array $mappers;
@@ -47,12 +47,9 @@ final readonly class ObjectEachMapper extends Mapper
         $result = [];
 
         for ($i = 0; $i < $this->count; $i++) {
-            $fake = [];
             foreach ($this->mappers as $mapper) {
-                $fake[$mapper->key] = $mapper->fake();
+                $result[$i][$mapper->key] = $mapper->fake();
             }
-
-            $result[$i] = (object) $fake;
         }
 
         return $result;

--- a/src/Attributes/ArrayMapper.php
+++ b/src/Attributes/ArrayMapper.php
@@ -5,24 +5,47 @@ declare(strict_types=1);
 namespace Sylarele\ObjectMetadataMapper\Attributes;
 
 use Attribute;
+use Override;
+use Sylarele\ObjectMetadataMapper\Helpers\Arr;
 
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 final readonly class ArrayMapper extends Mapper
 {
-    /**
-     * MUST NOT substitute {@link ObjectMapper ObjectMapper} or {@link ObjectEachMapper ObjectEachMapper}.
-     * Use only for simple arrays.
-     */
-    public function __construct(
-        string $key,
-        string $description = '',
-        public array $default = []
-    ) {
-        parent::__construct($key, $description);
+    /** @var array<array-key, Mapper> */
+    public array $mappers;
+
+    public function __construct(string $key, Mapper ...$mappers)
+    {
+        parent::__construct($key, '');
+        $this->mappers = $mappers;
+    }
+
+    #[Override]
+    public function descriptions(): array
+    {
+        $descriptions = [];
+
+        foreach ($this->mappers as $mapper) {
+            if ($mapper instanceof ObjectMapper || $mapper instanceof ObjectEachMapper) {
+                $descriptions = array_merge($descriptions, $mapper->descriptions());
+            } else {
+                $descriptions[$mapper->key] = $mapper->description;
+            }
+        }
+
+        return $this->key === ''
+            ? $descriptions
+            : Arr::prependKeysWith($descriptions, $this->key.'.');
     }
 
     public function fake(): array
     {
-        return $this->default;
+        $fake = [];
+
+        foreach ($this->mappers as $mapper) {
+            $fake[$mapper->key] = $mapper->fake();
+        }
+
+        return $fake;
     }
 }

--- a/src/Attributes/ObjectMapper.php
+++ b/src/Attributes/ObjectMapper.php
@@ -6,6 +6,7 @@ namespace Sylarele\ObjectMetadataMapper\Attributes;
 
 use Attribute;
 use Override;
+use stdClass;
 use Sylarele\ObjectMetadataMapper\Helpers\Arr;
 
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
@@ -38,7 +39,7 @@ readonly class ObjectMapper extends Mapper
             : Arr::prependKeysWith($descriptions, $this->key.'.');
     }
 
-    public function fake(): array
+    public function fake(): stdClass
     {
         $fake = [];
 
@@ -46,6 +47,6 @@ readonly class ObjectMapper extends Mapper
             $fake[$mapper->key] = $mapper->fake();
         }
 
-        return $fake;
+        return (object) $fake;
     }
 }

--- a/src/Attributes/StrictArrayEachMapper.php
+++ b/src/Attributes/StrictArrayEachMapper.php
@@ -9,7 +9,7 @@ use Override;
 use Sylarele\ObjectMetadataMapper\Helpers\Arr;
 
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
-final readonly class ObjectEachMapper extends Mapper
+final readonly class StrictArrayEachMapper extends Mapper
 {
     /** @var array<Mapper> */
     public array $mappers;
@@ -47,12 +47,9 @@ final readonly class ObjectEachMapper extends Mapper
         $result = [];
 
         for ($i = 0; $i < $this->count; $i++) {
-            $fake = [];
             foreach ($this->mappers as $mapper) {
-                $fake[$mapper->key] = $mapper->fake();
+                $result[$i][$mapper->key] = $mapper->fake();
             }
-
-            $result[$i] = (object) $fake;
         }
 
         return $result;

--- a/src/Attributes/StrictArrayMapper.php
+++ b/src/Attributes/StrictArrayMapper.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylarele\ObjectMetadataMapper\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+final readonly class StrictArrayMapper extends Mapper
+{
+    /**
+     * Use only for simple arrays.
+     */
+    public function __construct(
+        string $key,
+        string $description = '',
+        public array $default = []
+    ) {
+        parent::__construct($key, $description);
+    }
+
+    public function fake(): array
+    {
+        return $this->default;
+    }
+}

--- a/src/Contracts/MapperInterface.php
+++ b/src/Contracts/MapperInterface.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Sylarele\ObjectMetadataMapper\Contracts;
 
+use stdClass;
+
 /**
  * @phpstan-type DescriptionType array<string, string>
  */
 interface MapperInterface
 {
-    public function fake(): null|array|bool|int|string;
+    public function fake(): null|array|bool|int|string|stdClass;
 
     /**
      * @return DescriptionType

--- a/tests/Unit/Attributes/ArrayEachMapperTest.php
+++ b/tests/Unit/Attributes/ArrayEachMapperTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylarele\ObjectMetadataMapper\Tests\Unit\Attributes;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Sylarele\ObjectMetadataMapper\Attributes\ArrayEachMapper;
+use Sylarele\ObjectMetadataMapper\Attributes\StringMapper;
+
+#[CoversClass(ArrayEachMapper::class)]
+class ArrayEachMapperTest extends TestCase
+{
+    private ArrayEachMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new ArrayEachMapper(
+            'example',
+            2,
+            new StringMapper('title', 'my title description', 'Lorem ipsum'),
+        );
+    }
+
+    public function testFake(): void
+    {
+        $fake = $this->mapper->fake();
+
+        self::assertCount(2, $fake);
+        foreach ($fake as $value) {
+            self::assertIsArray($value);
+            self::assertSame('Lorem ipsum', $value['title']);
+        }
+    }
+
+    public function testDescription(): void
+    {
+        $description = $this->mapper->descriptions();
+
+        self::assertCount(2, $description);
+        self::assertEquals(
+            [
+                'example.0.title' => 'my title description',
+                'example.1.title' => 'my title description',
+            ],
+            $description
+        );
+    }
+}

--- a/tests/Unit/Attributes/ArrayMapperTest.php
+++ b/tests/Unit/Attributes/ArrayMapperTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylarele\ObjectMetadataMapper\Tests\Unit\Attributes;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Sylarele\ObjectMetadataMapper\Attributes\ArrayMapper;
+use Sylarele\ObjectMetadataMapper\Attributes\StringMapper;
+
+#[CoversClass(ArrayMapper::class)]
+class ArrayMapperTest extends TestCase
+{
+    private ArrayMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new ArrayMapper(
+            'example',
+            new StringMapper('title', 'my title description', 'Lorem ipsum'),
+        );
+    }
+
+    public function testFake(): void
+    {
+        $fake = $this->mapper->fake();
+
+        self::assertEquals('Lorem ipsum', $fake['title']);
+    }
+
+    public function testDescription(): void
+    {
+        $description = $this->mapper->descriptions();
+
+        self::assertEquals(
+            ['example.title' => 'my title description'],
+            $description
+        );
+    }
+}

--- a/tests/Unit/Attributes/ObjectEachMapperTest.php
+++ b/tests/Unit/Attributes/ObjectEachMapperTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylarele\ObjectMetadataMapper\Tests\Unit\Attributes;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Sylarele\ObjectMetadataMapper\Attributes\ObjectEachMapper;
+use Sylarele\ObjectMetadataMapper\Attributes\StringMapper;
+
+#[CoversClass(ObjectEachMapper::class)]
+class ObjectEachMapperTest extends TestCase
+{
+    private ObjectEachMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new ObjectEachMapper(
+            'example',
+            2,
+            new StringMapper('title', 'my title description', 'Lorem ipsum'),
+        );
+    }
+
+    public function testFake(): void
+    {
+        $fake = $this->mapper->fake();
+
+        self::assertCount(2, $fake);
+        foreach ($fake as $value) {
+            self::assertInstanceOf(stdClass::class, $value);
+            self::assertSame('Lorem ipsum', $value->title);
+        }
+    }
+
+    public function testDescription(): void
+    {
+        $description = $this->mapper->descriptions();
+
+        self::assertCount(2, $description);
+        self::assertEquals(
+            [
+                'example.0.title' => 'my title description',
+                'example.1.title' => 'my title description',
+            ],
+            $description
+        );
+    }
+}

--- a/tests/Unit/Attributes/ObjectMapperTest.php
+++ b/tests/Unit/Attributes/ObjectMapperTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylarele\ObjectMetadataMapper\Tests\Unit\Attributes;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Sylarele\ObjectMetadataMapper\Attributes\ObjectMapper;
+use Sylarele\ObjectMetadataMapper\Attributes\StringMapper;
+
+#[CoversClass(ObjectMapper::class)]
+class ObjectMapperTest extends TestCase
+{
+    private ObjectMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new ObjectMapper(
+            'example',
+            new StringMapper('title', 'my title description', 'Lorem ipsum'),
+        );
+    }
+
+    public function testFake(): void
+    {
+        $fake = $this->mapper->fake();
+
+        self::assertEquals('Lorem ipsum', $fake->title);
+    }
+
+    public function testDescription(): void
+    {
+        $description = $this->mapper->descriptions();
+
+        self::assertEquals(
+            ['example.title' => 'my title description'],
+            $description
+        );
+    }
+}

--- a/tests/Unit/Attributes/StrictArrayEachMapperTest.php
+++ b/tests/Unit/Attributes/StrictArrayEachMapperTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylarele\ObjectMetadataMapper\Tests\Unit\Attributes;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Sylarele\ObjectMetadataMapper\Attributes\StrictArrayMapper;
+
+#[CoversClass(StrictArrayMapper::class)]
+class StrictArrayEachMapperTest extends TestCase
+{
+    private StrictArrayMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new StrictArrayMapper(
+            'example',
+            'my example description',
+            [
+                'title' => 'Lorem ipsum',
+            ]
+        );
+    }
+
+    public function testFake(): void
+    {
+        $fake = $this->mapper->fake();
+
+        self::assertEquals('Lorem ipsum', $fake['title']);
+    }
+
+    public function testDescription(): void
+    {
+        $description = $this->mapper->descriptions();
+
+        self::assertEquals(
+            ['example' => 'my example description'],
+            $description
+        );
+    }
+}

--- a/tests/Unit/Attributes/StrictArrayMapperTest.php
+++ b/tests/Unit/Attributes/StrictArrayMapperTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylarele\ObjectMetadataMapper\Tests\Unit\Attributes;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Sylarele\ObjectMetadataMapper\Attributes\ArrayMapper;
+use Sylarele\ObjectMetadataMapper\Attributes\StrictArrayMapper;
+
+#[CoversClass(ArrayMapper::class)]
+class StrictArrayMapperTest extends TestCase
+{
+    private StrictArrayMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new StrictArrayMapper(
+            'example',
+            'my example description',
+            [
+                'title' => 'Lorem ipsum',
+            ]
+        );
+    }
+
+    public function testFake(): void
+    {
+        $fake = $this->mapper->fake();
+
+        self::assertEquals('Lorem ipsum', $fake['title']);
+    }
+
+    public function testDescription(): void
+    {
+        $description = $this->mapper->descriptions();
+
+        self::assertEquals(
+            ['example' => 'my example description'],
+            $description
+        );
+    }
+}

--- a/tests/Unit/MetadataServiceTest.php
+++ b/tests/Unit/MetadataServiceTest.php
@@ -35,13 +35,13 @@ class MetadataServiceTest extends TestCase
         );
         $this->assertEquals(
             [
-                'user' => [
+                'user' => (object) [
                     'fullname' => 'John Smith',
                     'phone' => '04 00 00 00 00',
                     'email' => 'fake@example.fr',
                     'addresses' => [
-                        ['address' => 'Av. Gustave Eiffel, 75007 Paris'],
-                        ['address' => 'Av. Gustave Eiffel, 75007 Paris'],
+                        (object) ['address' => 'Av. Gustave Eiffel, 75007 Paris'],
+                        (object) ['address' => 'Av. Gustave Eiffel, 75007 Paris'],
                     ],
                 ],
             ],


### PR DESCRIPTION
## Description

Les attributs 
- `ObjectMapper` renvoie un objet stdClass et prend en entrée une liste de Mapper,
- `ObjectEachMapper` renvoie un objet tableau de stdClass et prend en entrée une liste de Mapper,
- `ArrayMapper` renvoie un tableau et prend en entrée une liste de Mapper,
- `ArrayEachMapper` renvoie un tableau multidimensionnel et et prend en entrée une liste de Mapper,
- `StrictArrayMapper` renvoie un tableau et prend en entrée un tableau,
- `StrictArrayEachMapper` renvoie un tableau multidimensionnel et prend en entrée un tableau,